### PR TITLE
feat: EX score OCR'd end-to-end, with tap-to-correct ROI and physical-side 1P/2P selection

### DIFF
--- a/lib/components/ocr/load_image.dart
+++ b/lib/components/ocr/load_image.dart
@@ -369,6 +369,8 @@ String ocrFieldLabel(String key) {
   switch (key) {
     case 'maxCombo':
       return 'MAX COMBO';
+    case 'exScore':
+      return 'EX SCORE';
     default:
       return key.toUpperCase();
   }

--- a/lib/components/ocr/load_image.dart
+++ b/lib/components/ocr/load_image.dart
@@ -601,11 +601,14 @@ class FlareDropdownField extends StatelessWidget {
                                 children: [
                                   Image.asset(flareRankIcon(r), height: 18),
                                   const SizedBox(width: 8),
-                                  Text(
-                                    r,
-                                    style: const TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.w600,
+                                  Flexible(
+                                    child: Text(
+                                      r,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w600,
+                                      ),
                                     ),
                                   ),
                                 ],

--- a/lib/components/ocr/load_image.dart
+++ b/lib/components/ocr/load_image.dart
@@ -232,6 +232,32 @@ class _LoadImageState extends State<LoadImage> {
     }
   }
 
+  // Tap-to-pick: when the side heuristics anchor on the wrong box (easy with
+  // 3+ candidates), tapping the correct box re-runs OCR with that blob forced
+  // as the Details badge. Taps outside every box are ignored. [pos] is in the
+  // displayed-image space; the ROIs in _lastResult are already scaled to it,
+  // and dividing by the same scale recovers original-image pixels for native.
+  void _onRoiTap(Offset pos) {
+    final rois = _lastResult?.detectedRois;
+    if (rois == null || _isProcessing || _pickedImage == null) return;
+    final scale = _camFrameToScreenScale;
+    if (scale <= 0) return;
+    const slop = 12.0;
+    final hit = rois.any((r) => Rect.fromLTWH(r.left - slop, r.top - slop,
+            r.width + 2 * slop, r.height + 2 * slop)
+        .contains(pos));
+    if (!hit) return;
+    setState(() {
+      _lastResult = null;
+      _isProcessing = true;
+    });
+    _ocrProcessor.processPickedImage(
+      _pickedImage!,
+      tapPoint:
+          Point<int>((pos.dx / scale).round(), (pos.dy / scale).round()),
+    );
+  }
+
   // Floats over the loaded screenshot — and over the no-detection empty
   // state, where switching sides is how you retry the same image.
   Widget get _floatingSideSelector => Positioned(
@@ -306,13 +332,16 @@ class _LoadImageState extends State<LoadImage> {
                       children: [
                         Stack(
                           children: [
-                            RoiOverlay(
-                              rois: _lastResult!.detectedRois!,
-                              detailsRoiIndex: _lastResult!.detailsRoiIndex,
-                              child: Image.file(
-                                File(_pickedImage!.path),
-                                width: MediaQuery.of(context).size.width,
-                                fit: BoxFit.fitWidth,
+                            GestureDetector(
+                              onTapUp: (d) => _onRoiTap(d.localPosition),
+                              child: RoiOverlay(
+                                rois: _lastResult!.detectedRois!,
+                                detailsRoiIndex: _lastResult!.detailsRoiIndex,
+                                child: Image.file(
+                                  File(_pickedImage!.path),
+                                  width: MediaQuery.of(context).size.width,
+                                  fit: BoxFit.fitWidth,
+                                ),
                               ),
                             ),
                             _floatingSideSelector,
@@ -326,6 +355,16 @@ class _LoadImageState extends State<LoadImage> {
                             ),
                           ],
                         ),
+                        if (_lastResult!.detectedRois!.length > 1)
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                            child: Text(
+                              'Wrong box highlighted? Tap the correct Details '
+                              'box to re-scan.',
+                              style: TextStyle(
+                                  fontSize: 12, color: Colors.grey[600]),
+                            ),
+                          ),
                         if (hasScore)
                           Padding(
                             padding: const EdgeInsets.all(8.0),

--- a/lib/components/ocr/ocr_page.dart
+++ b/lib/components/ocr/ocr_page.dart
@@ -749,6 +749,7 @@ class _OcrPageState extends State<OcrPage>
 // Fields whose readings are numbers; everything else is tallied as raw text.
 const Set<String> _numericKeys = {
   'score',
+  'exScore',
   'marvelous',
   'perfect',
   'great',
@@ -801,10 +802,11 @@ class _OcrAggregator {
     _detailsCount = 0;
   }
 
-  // Formats a tally value for display: numbers get thousands separators, text
-  // passes through unchanged.
-  static String _display(Object value) =>
-      value is int ? _formatOcrNumber(value) : value as String;
+  // Formats a tally value for display: numbers get thousands separators
+  // (except EX score, which the game renders without them), text passes
+  // through unchanged.
+  static String _display(String key, Object value) =>
+      value is int && key != 'exScore' ? _formatOcrNumber(value) : '$value';
 
   ({String value, double confidence, int count})? best(String key) {
     final tally = _counts[key];
@@ -816,7 +818,7 @@ class _OcrAggregator {
       if (top == null || entry.value > top.value) top = entry;
     }
     return (
-      value: _display(top!.key),
+      value: _display(key, top!.key),
       confidence: top.value / total,
       count: top.value,
     );
@@ -830,7 +832,7 @@ class _OcrAggregator {
       ..sort((a, b) => b.value.compareTo(a.value));
     return [
       for (final e in entries)
-        (value: _display(e.key), count: e.value, share: e.value / total),
+        (value: _display(key, e.key), count: e.value, share: e.value / total),
     ];
   }
 }

--- a/lib/components/ocr/save_score.dart
+++ b/lib/components/ocr/save_score.dart
@@ -175,6 +175,7 @@ class _SaveScorePanelState extends State<SaveScorePanel> {
       // unresolvable reading the user never touched falls back to raw text.
       flare: resolveOcrFlare(_text('flare')) ?? _text('flare'),
       score: _number('score'),
+      exScore: _number('exScore'),
       marvelous: _number('marvelous'),
       perfect: _number('perfect'),
       great: _number('great'),
@@ -240,8 +241,8 @@ class _SaveScorePanelState extends State<SaveScorePanel> {
             isWeak: state.isWeak,
           ),
           if (state.song != null) _buildDifficultyRow(state.song!, mode),
-          if (widget.source == ScoreSource.loadImage) _buildDateRow(),
           if (widget.middleChildren.isNotEmpty) ...widget.middleChildren,
+          if (widget.source == ScoreSource.loadImage) _buildDateRow(),
           _buildUsernameMismatchWarning(),
           buildSaveButton(
             padding: EdgeInsets.only(top: widget.middleChildren.isEmpty ? 0 : 12),

--- a/lib/components/song/scores/score_card.dart
+++ b/lib/components/song/scores/score_card.dart
@@ -247,6 +247,7 @@ class _ScoreJudgments extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final judgments = <(String, String, int?)>[
+      ('EX', 'exScore', score.exScore),
       ('MARV.', 'marvelous', score.marvelous),
       ('PERF.', 'perfect', score.perfect),
       ('GREAT', 'great', score.great),

--- a/lib/components/song/scores/score_details_page.dart
+++ b/lib/components/song/scores/score_details_page.dart
@@ -18,19 +18,21 @@ import 'package:ddr_md/models/db_models.dart';
 import 'package:ddr_md/models/score_images.dart';
 import 'package:flutter/material.dart';
 
-// Editable columns of the scores table, in card display order. Date, song,
-// mode and the image stay fixed — they identify the score being corrected.
+// Editable columns of the scores table, matching the save-panel field order
+// (difficulty, score fields, username, flare). Song, mode and the image stay
+// fixed — they identify the score being corrected.
 const List<String> _kEditableKeys = [
   'difficulty',
-  'username',
-  'flare',
   'score',
+  'exScore',
   'marvelous',
   'perfect',
   'great',
   'good',
   'miss',
   'maxCombo',
+  'username',
+  'flare',
 ];
 
 class ScoreDetailsPage extends StatefulWidget {
@@ -68,6 +70,7 @@ class _ScoreDetailsPageState extends State<ScoreDetailsPage> {
       'username' => _score.username,
       'flare' => _score.flare,
       'score' => _score.score?.toString(),
+      'exScore' => _score.exScore?.toString(),
       'marvelous' => _score.marvelous?.toString(),
       'perfect' => _score.perfect?.toString(),
       'great' => _score.great?.toString(),
@@ -125,6 +128,7 @@ class _ScoreDetailsPageState extends State<ScoreDetailsPage> {
       // pre-existing unresolvable value left untouched stays raw.
       flare: resolveOcrFlare(_text('flare')) ?? _text('flare'),
       score: _number('score'),
+      exScore: _number('exScore'),
       marvelous: _number('marvelous'),
       perfect: _number('perfect'),
       great: _number('great'),
@@ -260,7 +264,6 @@ class _ScoreDetailsPageState extends State<ScoreDetailsPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  if (_dateEditable) _buildEditDateRow(),
                   for (final key in _kEditableKeys)
                     if (key == 'flare')
                       FlareDropdownField(controller: _controllers[key]!)
@@ -269,6 +272,7 @@ class _ScoreDetailsPageState extends State<ScoreDetailsPage> {
                         keyName: key,
                         controller: _controllers[key]!,
                       ),
+                  if (_dateEditable) _buildEditDateRow(),
                 ],
               ),
             )

--- a/lib/models/database.dart
+++ b/lib/models/database.dart
@@ -13,12 +13,12 @@ class DatabaseProvider {
     return _database;
   }
 
-  // v6 schema. `scores` and `notes` carry a UUID `id` as their stable identity,
+  // v7 schema. `scores` and `notes` carry a UUID `id` as their stable identity,
   // with the timestamp demoted to an ordinary editable column (`playedAt` /
   // `createdAt`) used only for display and sorting. `favorites` keeps its
   // integer key and its natural (songTitle, mode) uniqueness.
   static const String _scoresDdl =
-      'CREATE TABLE IF NOT EXISTS scores(id TEXT PRIMARY KEY, playedAt TEXT NOT NULL, source TEXT NOT NULL DEFAULT \'camera\', songTitle TEXT, mode TEXT NOT NULL, difficulty TEXT, username TEXT, flare TEXT, score INT, marvelous INT, perfect INT, great INT, good INT, miss INT, maxCombo INT, imagePath TEXT NOT NULL DEFAULT \'\')';
+      'CREATE TABLE IF NOT EXISTS scores(id TEXT PRIMARY KEY, playedAt TEXT NOT NULL, source TEXT NOT NULL DEFAULT \'camera\', songTitle TEXT, mode TEXT NOT NULL, difficulty TEXT, username TEXT, flare TEXT, score INT, exScore INT, marvelous INT, perfect INT, great INT, good INT, miss INT, maxCombo INT, imagePath TEXT NOT NULL DEFAULT \'\')';
   static const String _notesDdl =
       'CREATE TABLE IF NOT EXISTS notes(id TEXT PRIMARY KEY, createdAt TEXT NOT NULL, contents TEXT, songTitle TEXT, mode TEXT NOT NULL)';
   static const String _favoritesDdl =
@@ -32,7 +32,7 @@ class DatabaseProvider {
 
   static Future<Database> getDatabaseInstance() async {
     String path = join(await getDatabasesPath(), "ddr_database.db");
-    return await openDatabase(path, version: 6, onCreate: (db, version) async {
+    return await openDatabase(path, version: 7, onCreate: (db, version) async {
       await _createSchema(db);
     }, onUpgrade: (db, oldVersion, newVersion) async {
       // The app is not yet released and the pre-v6 tables overloaded their
@@ -44,6 +44,11 @@ class DatabaseProvider {
         await db.execute('DROP TABLE IF EXISTS notes');
         await db.execute('DROP TABLE IF EXISTS favorites');
         await _createSchema(db);
+      }
+      // v7: EX score OCR'd from the results screen. Nullable like the other
+      // count columns; pre-v7 rows simply have no reading.
+      if (oldVersion == 6) {
+        await db.execute('ALTER TABLE scores ADD COLUMN exScore INT');
       }
     });
   }

--- a/lib/models/db_models.dart
+++ b/lib/models/db_models.dart
@@ -75,6 +75,7 @@ class Score {
   final String username;
   final String flare;
   final int? score;
+  final int? exScore;
   final int? marvelous;
   final int? perfect;
   final int? great;
@@ -97,6 +98,7 @@ class Score {
     this.username = '',
     this.flare = '',
     this.score,
+    this.exScore,
     this.marvelous,
     this.perfect,
     this.great,
@@ -117,6 +119,7 @@ class Score {
       'username': username,
       'flare': flare,
       'score': score,
+      'exScore': exScore,
       'marvelous': marvelous,
       'perfect': perfect,
       'great': great,
@@ -140,6 +143,7 @@ class Score {
     String? username,
     String? flare,
     int? score,
+    int? exScore,
     int? marvelous,
     int? perfect,
     int? great,
@@ -158,6 +162,7 @@ class Score {
         username: username ?? this.username,
         flare: flare ?? this.flare,
         score: score ?? this.score,
+        exScore: exScore ?? this.exScore,
         marvelous: marvelous ?? this.marvelous,
         perfect: perfect ?? this.perfect,
         great: great ?? this.great,
@@ -177,6 +182,7 @@ class Score {
         username: json["username"] ?? '',
         flare: json["flare"] ?? '',
         score: json["score"],
+        exScore: json["exScore"],
         marvelous: json["marvelous"],
         perfect: json["perfect"],
         great: json["great"],

--- a/lib/ocr_config.dart
+++ b/lib/ocr_config.dart
@@ -68,6 +68,7 @@ const List<(List<int>, (int, int))> ocrRoi = [
   ([1752, 181, 1952, 220], (0, 0)), // username
   ([1766, 233, 2026, 300], (0, 0)), // difficulty
   ([2098, 1154, 2279, 1202], (0, 0)), // max_combo
+  ([2166, 1118, 2279, 1157], (0, 0)), // ex_score
 ];
 // Extra rects from the source table not wired into ocrRoi above (no
 // slot in the fixed ROI_IDX_* enum). Kept for reference:

--- a/lib/ocr_processor.dart
+++ b/lib/ocr_processor.dart
@@ -267,6 +267,8 @@ typedef _c_processPickedImage = Void Function(
   Pointer<Int32> outputdetailsRoiIndex,
   Pointer<COCRStrings> outStrings,
   Int32 side,
+  Int32 tapX,
+  Int32 tapY,
 );
 
 typedef _dart_processPickedImage = void Function(
@@ -278,6 +280,8 @@ typedef _dart_processPickedImage = void Function(
   Pointer<Int32> outputdetailsRoiIndex,
   Pointer<COCRStrings> outStrings,
   int side,
+  int tapX,
+  int tapY,
 );
 
 // Camera session FFI (operates on the opaque session pointer from the channel).
@@ -394,7 +398,8 @@ void _freeOcrStrings(Pointer<COCRStrings> p) {
 // Runs the picked-image FFI path inside a one-shot isolate so the (slow)
 // instance creation + OCR doesn't jank the UI thread. Creates and destroys a
 // transient DdrocrInstance for the single call.
-ProcessResult _runPickedImage(String appPath, String imagePath, int side) {
+ProcessResult _runPickedImage(
+    String appPath, String imagePath, int side, int tapX, int tapY) {
   final createFn =
       _nativeLib.lookupFunction<_c_createOcrInstance, _dart_createOcrInstance>(
           'create_ocr_instance');
@@ -427,6 +432,8 @@ ProcessResult _runPickedImage(String appPath, String imagePath, int side) {
     outputDetailsRoiIndex,
     outStrings,
     side,
+    tapX,
+    tapY,
   );
   calloc.free(imagePathPtr);
 
@@ -680,15 +687,20 @@ class OCRProcessor {
     }
   }
 
-  void processPickedImage(XFile image) async {
+  // [tapPoint] (original-image pixels) forces the candidate blob containing it
+  // to be the Details badge, bypassing the side heuristics — the load-image
+  // page sends it when the user taps a detected ROI box.
+  void processPickedImage(XFile image, {Point<int>? tapPoint}) async {
     print('Processing image from file: ${image.path}');
     isProcessing.value = true;
     try {
       final appPath = appDir!.path;
       final imagePath = image.path;
       final sideIndex = _side.index;
-      final result =
-          await Isolate.run(() => _runPickedImage(appPath, imagePath, sideIndex));
+      final tapX = tapPoint?.x ?? -1;
+      final tapY = tapPoint?.y ?? -1;
+      final result = await Isolate.run(
+          () => _runPickedImage(appPath, imagePath, sideIndex, tapX, tapY));
       streamResultController.add(result);
     } catch (e) {
       print('Picked image processing failed: $e');

--- a/lib/ocr_processor.dart
+++ b/lib/ocr_processor.dart
@@ -17,6 +17,7 @@ import 'package:path_provider/path_provider.dart';
 const List<String> kOcrFieldOrder = [
   'title',
   'score',
+  'exScore',
   'marvelous',
   'perfect',
   'great',
@@ -111,6 +112,7 @@ class ProcessResult {
       'username': rd(r.username),
       'difficulty': rd(r.difficulty),
       'maxCombo': rd(r.maxCombo),
+      'exScore': rd(r.exScore),
     };
 
     Uint8List? img(Pointer<Uint8> buf, int len) =>
@@ -182,7 +184,7 @@ final class COCRConfig extends Struct {
   external int morphWidth;
   @Int32()
   external int morphHeight;
-  @Array(12, 6)
+  @Array(13, 6)
   external Array<Array<Int32>> roi;
   @Array(4)
   external Array<Int32> combinedRoi;
@@ -206,6 +208,7 @@ final class COCRStrings extends Struct {
   external Pointer<Char> username;
   external Pointer<Char> difficulty;
   external Pointer<Char> maxCombo;
+  external Pointer<Char> exScore;
 }
 
 // Layout must match camera_result.h::CCameraResult exactly.
@@ -232,6 +235,7 @@ final class CCameraResult extends Struct {
   external Pointer<Char> username;
   external Pointer<Char> difficulty;
   external Pointer<Char> maxCombo;
+  external Pointer<Char> exScore;
   external Pointer<Uint8> mask;
   @Int32()
   external int maskLen;
@@ -327,7 +331,7 @@ Pointer<COCRConfig> _buildOCRConfig() {
   p.ref.tophatKernelSize = ocrTophatKernelSize;
   p.ref.morphWidth = ocrMorphWidth;
   p.ref.morphHeight = ocrMorphHeight;
-  for (int r = 0; r < 12; r++) {
+  for (int r = 0; r < ocrRoi.length; r++) {
     final (rect, (ex, ey)) = ocrRoi[r];
     p.ref.roi[r][roiX1] = rect[roiX1];
     p.ref.roi[r][roiY1] = rect[roiY1];
@@ -362,6 +366,7 @@ Map<String, String> _readOcrStrings(Pointer<COCRStrings> p) {
     'username': read(r.username),
     'difficulty': read(r.difficulty),
     'maxCombo': read(r.maxCombo),
+    'exScore': read(r.exScore),
   };
 }
 
@@ -378,7 +383,8 @@ void _freeOcrStrings(Pointer<COCRStrings> p) {
     r.title,
     r.username,
     r.difficulty,
-    r.maxCombo
+    r.maxCombo,
+    r.exScore
   ]) {
     if (s != nullptr) calloc.free(s);
   }
@@ -613,7 +619,7 @@ class OCRProcessor {
   // native camera session reconstructs into a COCRConfig. Field order MUST match
   // config_marshal.h::BuildCOCRConfigFromArrays.
   (Int32List, Float64List) _buildCameraConfigArrays() {
-    final ints = Int32List(83);
+    final ints = Int32List(89);
     ints[0] = ocrBorder;
     ints[1] = ocrPsmEng;
     ints[2] = ocrPsmEngJP;
@@ -622,7 +628,7 @@ class OCRProcessor {
     ints[5] = ocrMorphWidth;
     ints[6] = ocrMorphHeight;
     int k = 7;
-    for (int r = 0; r < 12; r++) {
+    for (int r = 0; r < ocrRoi.length; r++) {
       final (rect, (ex, ey)) = ocrRoi[r];
       ints[k++] = rect[roiX1];
       ints[k++] = rect[roiY1];

--- a/native_opencv/ios/Classes/camera_result.h
+++ b/native_opencv/ios/Classes/camera_result.h
@@ -37,6 +37,7 @@ struct CCameraResult {
   char *username;
   char *difficulty;
   char *maxCombo;
+  char *exScore;
   uint8_t *mask;   int32_t maskLen;     // PNG, full-frame binarized (debug)
   uint8_t *crop;   int32_t cropLen;     // PNG, matched Details crop (debug)
   uint8_t *capture; int32_t captureLen; // JPEG, color frame on a match
@@ -108,6 +109,7 @@ static inline CCameraResult *BuildCCameraResult(const ProcessImgResult &r,
   c->username = ccr_dup(o.username.text);
   c->difficulty = ccr_dup(o.difficulty.text);
   c->maxCombo = ccr_dup(o.max_combo.text);
+  c->exScore = ccr_dup(o.ex_score.text);
   ccr_encode(r.debugMask, ".png", &c->mask, &c->maskLen);
   ccr_encode(r.debugDetailsCrop, ".png", &c->crop, &c->cropLen);
   ccr_encode(r.colorCapture, ".jpg", &c->capture, &c->captureLen);
@@ -129,6 +131,7 @@ static inline void FreeCCameraResult(CCameraResult *c) {
   free(c->username);
   free(c->difficulty);
   free(c->maxCombo);
+  free(c->exScore);
   free(c->mask);
   free(c->crop);
   free(c->capture);

--- a/native_opencv/ios/Classes/config_marshal.h
+++ b/native_opencv/ios/Classes/config_marshal.h
@@ -13,8 +13,8 @@
 //   ints[4]  tophat_kernel_size
 //   ints[5]  morph_width
 //   ints[6]  morph_height
-//   ints[7..78]   roi[12][6]  (row-major)
-//   ints[79..82]  combinedRoi[4]
+//   ints[7..84]   roi[13][6]  (row-major)
+//   ints[85..88]  combinedRoi[4]
 //
 //   doubles[0]  simplification_epsilon
 //   doubles[1]  area_min_factor
@@ -28,7 +28,7 @@
 #include <cstdint>
 #include "ddrocr_instance.h"
 
-static const int kCfgIntCount = 83;
+static const int kCfgIntCount = 89;
 static const int kCfgDoubleCount = 7;
 
 // Returns a COCRConfig built from the arrays, or the struct defaults if either
@@ -51,7 +51,7 @@ static inline COCRConfig BuildCOCRConfigFromArrays(const int32_t *ints, int ni,
     cfg.morph_height = ints[6];
 
     int k = 7;
-    for (int r = 0; r < 12; r++) {
+    for (int r = 0; r < 13; r++) {
         for (int c = 0; c < 6; c++) {
             cfg.roi[r][c] = ints[k++];
         }

--- a/native_opencv/ios/Classes/ddrocr_instance.cpp
+++ b/native_opencv/ios/Classes/ddrocr_instance.cpp
@@ -121,7 +121,9 @@ cv::Mat DdrocrInstance::logicalToDisplayU8(const cv::Mat &logical) const
 // needs. NO PaddleOCR runs here.
 // ---------------------------------------------------------------------------
 DetailsDetectResult DdrocrInstance::detect_details(cv::Mat inputImg, DetectionSide side,
-                                                   DebugImageType debugImageType)
+                                                   DebugImageType debugImageType,
+                                                   cv::Point tapPoint,
+                                                   bool strictSide)
 {
     DetailsDetectResult det;
     det.side = side;
@@ -407,13 +409,58 @@ DetailsDetectResult DdrocrInstance::detect_details(cv::Mat inputImg, DetectionSi
                          wantLeft ? "left" : "right", bestPartner,
                          bestPartnerScore, minScore);
         }
-        else if (bandBlobOnWantedSide)
+        else if (bandBlobOnWantedSide && strictSide)
         {
             sideRejected = true;
             platform_log("[DETAILS_DET] requested %s side has a band blob but no "
                          "recognisable badge — skipping frame instead of using "
                          "wrong-side badge %d\n",
                          wantLeft ? "left" : "right", chosenIdx);
+        }
+        else if (bandBlobOnWantedSide)
+        {
+            // One-shot caller: no next frame to wait for, so keep the best
+            // match auto-selected and let the user tap-correct it.
+            platform_log("[DETAILS_DET] requested %s side unreadable — one-shot "
+                         "caller, falling back to badge %d\n",
+                         wantLeft ? "left" : "right", chosenIdx);
+        }
+    }
+
+    // Manual override: the user tapped a candidate box on the live preview. A
+    // tap is authoritative — it bypasses the template gate and the side
+    // heuristics entirely (the homography only needs the blob's contour, not
+    // its match score). The point is in processed-frame pixels and persists
+    // across frames, so it keeps selecting whatever candidate contains it; if
+    // the framing drifts and no box contains it any more, the heuristics above
+    // stay in charge.
+    if (tapPoint.x >= 0 && tapPoint.y >= 0)
+    {
+        int    tapIdx = -1;
+        double tapDist = 0;
+        for (size_t i = 0; i < detectedRois.size(); ++i)
+        {
+            const cv::Rect &r = detectedRois[i];
+            // Inflate a little so taps just outside a thin box still count.
+            const int mx = r.width / 4, my = r.height / 4;
+            const cv::Rect hit(r.x - mx, r.y - my,
+                               r.width + 2 * mx, r.height + 2 * my);
+            if (!hit.contains(tapPoint)) continue;
+            const double dx = r.x + r.width * 0.5 - tapPoint.x;
+            const double dy = r.y + r.height * 0.5 - tapPoint.y;
+            const double dist = dx * dx + dy * dy;
+            if (tapIdx < 0 || dist < tapDist)
+            {
+                tapIdx = (int)i;
+                tapDist = dist;
+            }
+        }
+        if (tapIdx >= 0)
+        {
+            detectedDetailsIndices.assign(1, tapIdx);
+            sideRejected = false;
+            platform_log("[DETAILS_DET] tap override (%d,%d) -> candidate %d\n",
+                         tapPoint.x, tapPoint.y, tapIdx);
         }
     }
 
@@ -1179,9 +1226,12 @@ ProcessImgResult DdrocrInstance::recognise_details(const DetailsDetectResult &de
 // tooling. The live camera session calls detect_details / recognise_details on
 // separate threads instead.
 ProcessImgResult DdrocrInstance::process_image(cv::Mat inputImg, DetectionSide side,
-                                               DebugImageType debugImageType)
+                                               DebugImageType debugImageType,
+                                               cv::Point tapPoint,
+                                               bool strictSide)
 {
-    DetailsDetectResult det = detect_details(inputImg, side, debugImageType);
+    DetailsDetectResult det =
+        detect_details(inputImg, side, debugImageType, tapPoint, strictSide);
     if (!det.matched)
         return det.result;
     return recognise_details(det);

--- a/native_opencv/ios/Classes/ddrocr_instance.cpp
+++ b/native_opencv/ios/Classes/ddrocr_instance.cpp
@@ -313,6 +313,10 @@ DetailsDetectResult DdrocrInstance::detect_details(cv::Mat inputImg, DetectionSi
     // the best one. Re-run a small loop to collect every candidate that
     // cleared the same threshold, then pick by side.
     std::vector<int> detectedDetailsIndices;
+    // Per-candidate solo template scores, filled by the side-gate loop below
+    // (side != FIRST only). Reused by the wrong-side partner check so it
+    // doesn't have to re-run matchTemplate.
+    std::vector<float> candScores(detectedRois.size(), -1.0f);
     if (dmatch.index >= 0)
     {
         if (side == DetectionSide::FIRST)
@@ -334,6 +338,7 @@ DetailsDetectResult DdrocrInstance::detect_details(cv::Mat inputImg, DetectionSi
             {
                 std::vector<cv::Rect> one{detectedRois[i]};
                 auto m = detailsDetector.classify(inputImg, one, sideMin);
+                candScores[i] = m.score; // best score even when below sideMin
                 if (m.index == 0)
                 {
                     detectedDetailsIndices.push_back((int)i);
@@ -343,6 +348,72 @@ DetailsDetectResult DdrocrInstance::detect_details(cv::Mat inputImg, DetectionSi
             }
             if (detectedDetailsIndices.empty())
                 detectedDetailsIndices.push_back(dmatch.index);
+        }
+    }
+
+    // With LEFT/RIGHT requested but only ONE candidate surviving the gate, the
+    // positional pick below degenerates to "best match wins" and the requested
+    // side has no influence — selecting 1P can silently lock onto the 2P badge
+    // whenever the other player's badge scored under the gate. The two badges
+    // sit in the same horizontal band, mirror-separated by several badge
+    // widths, so look for the partner among the remaining HSV blobs on the
+    // requested side of the survivor:
+    //  - a partner that clears the base minScore (only the tighter side gate
+    //    filtered it) gets promoted so the positional pick can choose it;
+    //  - a band blob that is NOT recognisable as a badge means the requested
+    //    side is visible but unreadable this frame — skip the frame rather
+    //    than anchor the homography on the wrong player's panel.
+    // No band blob on the requested side (single-panel framing) keeps the
+    // current best-match behaviour: a lone badge is genuinely ambiguous.
+    bool sideRejected = false;
+    if (side != DetectionSide::FIRST && detectedDetailsIndices.size() == 1)
+    {
+        const int chosenIdx = detectedDetailsIndices[0];
+        const cv::Rect &chosen = detectedRois[chosenIdx];
+        const float cx = chosen.x + chosen.width * 0.5f;
+        const float cy = chosen.y + chosen.height * 0.5f;
+        const bool wantLeft = (side == DetectionSide::LEFT);
+        // Minimum centre-to-centre distance (in badge widths) for a blob to be
+        // the other panel's badge rather than an adjacent sibling tab. The
+        // real pair sits ~4 badge widths apart in the reference layout.
+        const float minPartnerDist = 2.5f * (float)chosen.width;
+        int   bestPartner = -1;
+        float bestPartnerScore = -1.0f;
+        bool  bandBlobOnWantedSide = false;
+        for (size_t i = 0; i < detectedRois.size(); ++i)
+        {
+            if ((int)i == chosenIdx) continue;
+            const cv::Rect &r = detectedRois[i];
+            const float rx = r.x + r.width * 0.5f;
+            const float ry = r.y + r.height * 0.5f;
+            if (wantLeft ? (rx >= cx) : (rx <= cx)) continue;
+            // Same tab-row band and comparable size as the surviving badge.
+            if (std::abs(ry - cy) > (float)chosen.height) continue;
+            if (r.height * 2 < chosen.height || r.height > chosen.height * 2) continue;
+            if (r.width * 2 < chosen.width || r.width > chosen.width * 2) continue;
+            if (std::abs(rx - cx) < minPartnerDist) continue;
+            bandBlobOnWantedSide = true;
+            if (candScores[i] >= minScore && candScores[i] > bestPartnerScore)
+            {
+                bestPartnerScore = candScores[i];
+                bestPartner = (int)i;
+            }
+        }
+        if (bestPartner >= 0)
+        {
+            detectedDetailsIndices.push_back(bestPartner);
+            platform_log("[DETAILS_DET] promoted %s-side partner %d score=%.3f "
+                         "(under side gate, over minScore %.2f)\n",
+                         wantLeft ? "left" : "right", bestPartner,
+                         bestPartnerScore, minScore);
+        }
+        else if (bandBlobOnWantedSide)
+        {
+            sideRejected = true;
+            platform_log("[DETAILS_DET] requested %s side has a band blob but no "
+                         "recognisable badge — skipping frame instead of using "
+                         "wrong-side badge %d\n",
+                         wantLeft ? "left" : "right", chosenIdx);
         }
     }
 
@@ -363,12 +434,15 @@ DetailsDetectResult DdrocrInstance::detect_details(cv::Mat inputImg, DetectionSi
     result.rois = detectedRois;
     save_img("BW3", BW3);
 
-    if (detectedDetailsIndices.empty())
+    if (detectedDetailsIndices.empty() || sideRejected)
     {
         auto t_total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::high_resolution_clock::now() - t_total_start).count();
         platform_log("[TIMER] process_image total (no Details found): %lld ms\n", (long long)t_total_ms);
-        platform_log("Details template match failed (best score=%.3f). Defaulting to no match.\n", dmatch.score);
+        if (sideRejected)
+            platform_log("Details badge only found on the wrong side (score=%.3f). Skipping frame.\n", dmatch.score);
+        else
+            platform_log("Details template match failed (best score=%.3f). Defaulting to no match.\n", dmatch.score);
         result.detailsRoiIndex = -1;
         return det;
     }

--- a/native_opencv/ios/Classes/ddrocr_instance.cpp
+++ b/native_opencv/ios/Classes/ddrocr_instance.cpp
@@ -44,6 +44,7 @@ static const int ROI_IDX_TITLE      = 8;
 static const int ROI_IDX_USERNAME   = 9;
 static const int ROI_IDX_DIFFICULTY = 10;
 static const int ROI_IDX_MAXCOMBO   = 11;
+static const int ROI_IDX_EXSCORE    = 12;
 
 
 DdrocrInstance::DdrocrInstance(std::string dataPath, const COCRConfig &cfg,
@@ -470,6 +471,7 @@ ProcessImgResult DdrocrInstance::recognise_details(const DetailsDetectResult &de
     cv::Rect ROI_Username   = roiRect(ROI_IDX_USERNAME);
     cv::Rect ROI_Difficulty = roiRect(ROI_IDX_DIFFICULTY);
     cv::Rect ROI_MaxCombo   = roiRect(ROI_IDX_MAXCOMBO);
+    cv::Rect ROI_ExScore    = roiRect(ROI_IDX_EXSCORE);
 
     // Calibration is anchored on the P2 (right) panel's badge. Fields inside
     // the player's own score panel keep the same badge-relative offset on both
@@ -665,6 +667,7 @@ ProcessImgResult DdrocrInstance::recognise_details(const DetailsDetectResult &de
                 {"miss",      fieldInCombinedCrop(ROI_Miss)},
                 {"flare",     fieldInCombinedCrop(ROI_Flare)},
                 {"max_combo", fieldInCombinedCrop(ROI_MaxCombo)},
+                {"ex_score",  fieldInCombinedCrop(ROI_ExScore)},
             };
             const cv::Rect cropBounds(0, 0, annotated.cols, annotated.rows);
             for (const auto &a : anchors)
@@ -788,6 +791,7 @@ ProcessImgResult DdrocrInstance::recognise_details(const DetailsDetectResult &de
         {"miss",      &ROI_Miss,      &ocrResults.miss,      -1},
         {"flare",     &ROI_Flare,     &ocrResults.flare,     -1},
         {"max_combo", &ROI_MaxCombo,  &ocrResults.max_combo, -1},
+        {"ex_score",  &ROI_ExScore,   &ocrResults.ex_score,  -1},
     };
     for (auto &f : combinedFields)
     {
@@ -913,6 +917,7 @@ ProcessImgResult DdrocrInstance::recognise_details(const DetailsDetectResult &de
         drawField(ROI_Miss,       ROI_IDX_MISS,       "miss");
         drawField(ROI_Flare,      ROI_IDX_FLARE,      "flare");
         drawField(ROI_MaxCombo,   ROI_IDX_MAXCOMBO,   "max_combo");
+        drawField(ROI_ExScore,    ROI_IDX_EXSCORE,    "ex_score");
         drawField(ROI_Title,      ROI_IDX_TITLE,      "title");
         drawField(ROI_Username,   ROI_IDX_USERNAME,   "username");
         drawField(ROI_Difficulty, ROI_IDX_DIFFICULTY, "difficulty");

--- a/native_opencv/ios/Classes/ddrocr_instance.cpp
+++ b/native_opencv/ios/Classes/ddrocr_instance.cpp
@@ -894,6 +894,13 @@ ProcessImgResult DdrocrInstance::recognise_details(const DetailsDetectResult &de
             t.erase(std::remove(t.begin(), t.end(), '/'), t.end());
     }
 
+    // The game renders EX score without thousands separators (unlike the
+    // money score), so any comma the recogniser emits there is OCR noise.
+    {
+        std::string &t = ocrResults.ex_score.text;
+        t.erase(std::remove(t.begin(), t.end(), ','), t.end());
+    }
+
     // ----- Outside the combined ROI: per-ROI recogniser-only fallback -----
     // title/username/difficulty/details sit above the score panel.
     ocrResults.title = getPreprocessedRoiImage(

--- a/native_opencv/ios/Classes/ddrocr_instance.h
+++ b/native_opencv/ios/Classes/ddrocr_instance.h
@@ -200,14 +200,27 @@ public:
     // TODO use outputimg path declared in class
     // Full pipeline: detect_details followed by recognise_details (when a badge
     // matched). Kept for the picked-image FFI path and offline tooling.
+    // tapPoint / strictSide: see detect_details.
     ProcessImgResult process_image(cv::Mat inputImg, DetectionSide side = DetectionSide::FIRST,
-                                   DebugImageType debugImageType = DebugImageType::NONE);
+                                   DebugImageType debugImageType = DebugImageType::NONE,
+                                   cv::Point tapPoint = cv::Point(-1, -1),
+                                   bool strictSide = true);
     // Phase 1 (cheap, run every frame): HSV mask -> blob filter -> Details
     // template match. Returns the detected ROIs + chosen index plus the geometry
     // phase 2 needs. Does NOT run any PaddleOCR.
+    // tapPoint (processed-frame pixels, {-1,-1} = none) is a user override: the
+    // candidate blob containing it is chosen as the Details badge, bypassing
+    // the template gate and side heuristics for that frame.
+    // strictSide governs what happens when the requested LEFT/RIGHT side is
+    // visible but its badge isn't recognisable: true (live camera) rejects the
+    // frame — a later frame will do better; false (one-shot callers like the
+    // picked-image path, which have no next frame) falls back to the best
+    // match so something is always auto-selected and the user can tap-correct.
     DetailsDetectResult detect_details(cv::Mat inputImg,
                                        DetectionSide side = DetectionSide::FIRST,
-                                       DebugImageType debugImageType = DebugImageType::NONE);
+                                       DebugImageType debugImageType = DebugImageType::NONE,
+                                       cv::Point tapPoint = cv::Point(-1, -1),
+                                       bool strictSide = true);
     // Phase 2 (expensive, run from the consumer thread): homography warp +
     // PaddleOCR det/rec over the score panel. Consumes a matched
     // DetailsDetectResult and returns the completed ProcessImgResult.

--- a/native_opencv/ios/Classes/ddrocr_instance.h
+++ b/native_opencv/ios/Classes/ddrocr_instance.h
@@ -33,6 +33,7 @@ struct OCRResults
     OCRResult username;
     OCRResult difficulty;
     OCRResult max_combo;
+    OCRResult ex_score;
 };
 
 // Whether the pipeline should capture debug images for on-device inspection.
@@ -97,17 +98,17 @@ struct ProcessImgResult
 // offset 48: tophat_kernel_size   int32_t
 // offset 52: morph_width          int32_t  (HSV blob morphology kernel width)
 // offset 56: morph_height         int32_t  (HSV blob morphology kernel height)
-// offset 60: roi[12][6]           int32_t[72]
-// offset 348: combinedRoi[4]      int32_t[4]
-// offset 368: details_template_min_score    double (4 bytes padding before)
-// offset 376: details_side_gate_factor      double
-// offset 384: homography_min_quad_coverage  double
-// total: 392 bytes
+// offset 60: roi[13][6]           int32_t[78]
+// offset 372: combinedRoi[4]      int32_t[4]
+// offset 392: details_template_min_score    double (4 bytes padding before)
+// offset 400: details_side_gate_factor      double
+// offset 408: homography_min_quad_coverage  double
+// total: 416 bytes
 //
 // roi row: {x1, y1, x2, y2, expand_x, expand_y}
 // roi order: details(0), score(1), marvelous(2), perfect(3), great(4),
 //            good(5), miss(6), flare(7), title(8), username(9),
-//            difficulty(10), max_combo(11)
+//            difficulty(10), max_combo(11), ex_score(12)
 struct COCRConfig
 {
     int32_t border                    = 30;
@@ -121,24 +122,25 @@ struct COCRConfig
     int32_t tophat_kernel_size        = 125;     // morphological top-hat kernel size (must be odd)
     int32_t morph_width               = 360;     // HSV blob morphology opening kernel width
     int32_t morph_height              = 90;      // HSV blob morphology opening kernel height
-    int32_t roi[12][6] = {
-        {2054,2348,2418,2450, 0, 0}, // details
-        {2700,2551,2968,2611, 5, 0}, // score
-        {1896,2549,2018,2599, 0, 0}, // marvelous
-        {1896,2608,2018,2657, 0, 4}, // perfect
-        {1896,2664,2018,2702, 0, 6}, // great
-        {1896,2727,2018,2771, 0, 5}, // good
-        {1896,2825,2018,2879, 0, 0}, // miss
-        {1649,2466,1817,2508, 0, 7}, // flare
-        {1210,2075,1744,2133, 0,10}, // title
-        {2180,1388,2465,1439,10,10}, // username
-        {2056,1463,2627,1536,10,10}, // difficulty
-        {2665,2779,2797,2831, 0, 0}, // max_combo
+    int32_t roi[13][6] = {
+        {1669, 864,1920, 936, 0, 0}, // details
+        {2129,1005,2273,1042, 5, 6}, // score
+        {1540,1013,1642,1050, 0, 0}, // marvelous
+        {1540,1049,1642,1086, 0, 0}, // perfect
+        {1540,1085,1642,1122, 0, 0}, // great
+        {1540,1121,1642,1158, 0, 0}, // good
+        {1540,1193,1642,1230, 0, 2}, // miss
+        {1385, 954,1507, 984, 0, 0}, // flare
+        {1051, 669,1506, 719, 0, 0}, // title
+        {1752, 181,1952, 220, 0, 0}, // username
+        {1766, 233,2026, 300, 0, 0}, // difficulty
+        {2098,1154,2279,1202, 0, 0}, // max_combo
+        {2166,1118,2279,1157, 0, 0}, // ex_score
     };
-    // Combined ROI {x1,y1,x2,y2} in warped 4000x5000 space — covers the score
-    // panel. Fed to the PaddleOCR detection model; detected boxes are then
-    // mapped to the score-panel fields via the per-field roi[] anchors above.
-    int32_t combinedRoi[4] = {1648, 2439, 2959, 2848};
+    // Combined ROI {x1,y1,x2,y2} — covers the score panel. Fed to the
+    // PaddleOCR detection model; detected boxes are then mapped to the
+    // score-panel fields via the per-field roi[] anchors above.
+    int32_t combinedRoi[4] = {1299, 860, 2296, 1239};
     // DetailsDetector::classify threshold (TM_CCOEFF_NORMED). See
     // ocr_config.dart::ocrDetailsTemplateMinScore for the source of truth.
     double  details_template_min_score = 0.4;

--- a/native_opencv/ios/Classes/native_opencv.cpp
+++ b/native_opencv/ios/Classes/native_opencv.cpp
@@ -154,7 +154,9 @@ extern "C"
         int32_t *outputRoisCount,
         int32_t *outputdetailsRoiIndex,
         COCRStrings *outStrings,
-        int32_t side)
+        int32_t side,
+        int32_t tapX,
+        int32_t tapY)
     {
         DdrocrInstance *instance = static_cast<DdrocrInstance *>(handle);
 
@@ -165,8 +167,12 @@ extern "C"
             *outputIsDetected = 0;
             return;
         }
+        // strictSide=false: this is a one-shot run with no next frame, so a
+        // wrong-side situation falls back to the best match (tap-correctable)
+        // instead of returning nothing.
         ProcessImgResult result = instance->process_image(
-            img, static_cast<DetectionSide>(side), DebugImageType::ON);
+            img, static_cast<DetectionSide>(side), DebugImageType::ON,
+            cv::Point(tapX, tapY), /*strictSide=*/false);
         if (!result.isDetected)
         {
             platform_log("No OCR region detected.\n");

--- a/native_opencv/ios/Classes/native_opencv.cpp
+++ b/native_opencv/ios/Classes/native_opencv.cpp
@@ -70,6 +70,7 @@ typedef struct
     char *username;
     char *difficulty;
     char *maxCombo;
+    char *exScore;
 } COCRStrings;
 
 // Helper function to convert std::string to char* (caller must free the result)
@@ -117,6 +118,7 @@ static void writeResult(
     outStrings->username = allocCString(ocr.username.text);
     outStrings->difficulty = allocCString(ocr.difficulty.text);
     outStrings->maxCombo = allocCString(ocr.max_combo.text);
+    outStrings->exScore = allocCString(ocr.ex_score.text);
 }
 
 // Avoiding name mangling

--- a/native_opencv/tools/model_compare/index.html
+++ b/native_opencv/tools/model_compare/index.html
@@ -97,8 +97,8 @@
 
 <script>
 // Fields to label — must match what results_viewer compares against.
-const FIELDS = ["score","marvelous","perfect","great","good","miss","max_combo","title"];
-const NUMERIC = new Set(["score","marvelous","perfect","great","good","miss","max_combo"]);
+const FIELDS = ["score","ex_score","marvelous","perfect","great","good","miss","max_combo","title"];
+const NUMERIC = new Set(["score","ex_score","marvelous","perfect","great","good","miss","max_combo"]);
 const LS_KEY = "ocr_classified_draft_v1";
 
 let imgs = [];        // [{name, url}]

--- a/native_opencv/tools/model_compare/main.cpp
+++ b/native_opencv/tools/model_compare/main.cpp
@@ -49,14 +49,14 @@ struct NamedRoiSet
 
 // Mirrors lib/ocr_config.dart. roi[] rows are {x1,y1,x2,y2,expand_x,expand_y}
 // in ROI_IDX_* order: details, score, marvelous, perfect, great, good, miss,
-// flare, title, username, difficulty, max_combo. Keep in sync with
+// flare, title, username, difficulty, max_combo, ex_score. Keep in sync with
 // ocrRoi (+ its paired ocrCombinedRoi) in Dart.
 COCRConfig makeReferenceConfig()
 {
     COCRConfig c; // inherits non-ROI defaults (border, thresholds, etc.)
     // Struct defaults now match lib/ocr_config.dart (the app's FFI source of
     // truth), so no per-field overrides are needed here.
-    int roi[12][6] = {
+    int roi[13][6] = {
         {1669, 864, 1920, 936, 0, 0},   // details
         {2129, 1005, 2273, 1042, 5, 6}, // score
         {1540, 1013, 1642, 1050, 0, 0}, // marvelous
@@ -69,6 +69,7 @@ COCRConfig makeReferenceConfig()
         {1752, 181, 1952, 220, 0, 0},   // username
         {1766, 233, 2026, 300, 0, 0},   // difficulty
         {2098, 1154, 2279, 1202, 0, 0}, // max_combo
+        {2166, 1118, 2279, 1157, 0, 0}, // ex_score
     };
     memcpy(c.roi, roi, sizeof(roi));
     int combined[4] = {1299, 860, 2296, 1239};
@@ -76,11 +77,11 @@ COCRConfig makeReferenceConfig()
     return c;
 }
 
-// The 12 fields in OCRResults, in a fixed display order.
+// The fields in OCRResults, in a fixed display order.
 const std::vector<std::string> kFields = {
     "score", "marvelous", "perfect", "great", "good", "miss",
-    "flare", "title", "username", "difficulty", "max_combo"};
-// (note: "ok" is not a field in OCRResults; OCRResults has 11 fields total)
+    "flare", "title", "username", "difficulty", "max_combo", "ex_score"};
+// (note: "ok" is not a field in OCRResults; OCRResults has 12 fields total)
 
 // Pull a field's OCRResult out of OCRResults by name.
 const OCRResult &fieldResult(const OCRResults &r, const std::string &f)
@@ -96,6 +97,7 @@ const OCRResult &fieldResult(const OCRResults &r, const std::string &f)
     if (f == "username")   return r.username;
     if (f == "difficulty") return r.difficulty;
     if (f == "max_combo")  return r.max_combo;
+    if (f == "ex_score")   return r.ex_score;
     static OCRResult empty;
     return empty;
 }

--- a/native_opencv/tools/model_compare/results_viewer.html
+++ b/native_opencv/tools/model_compare/results_viewer.html
@@ -183,7 +183,7 @@ const MODELS = ["mobile_v5", "small_v6", "tiny_v6", "medium_v6"];
 const IMG_BASE = "results_images";
 
 const NUMERIC_FIELDS = new Set(
-  ["score","marvelous","perfect","great","good","miss","max_combo"]);
+  ["score","ex_score","marvelous","perfect","great","good","miss","max_combo"]);
 
 let rows = [];          // parsed CSV rows (objects)
 let imageBlobUrls = {}; // "model/filename.png" -> objectURL (when dir picked)


### PR DESCRIPTION
## Intent

Get the EX score off the results screen and into score tracking, and make the two OCR selection mechanisms (which player's details, which region is the details box) reflect what's physically on screen instead of guessing.

## What's in here

### EX score end-to-end (604c218, e9b1491)
- New `ex_score` ROI in `ocr_config.dart`, threaded through the FFI structs (`COCRConfig` ROI array 12→13 rows, `COCRStrings`/`CCameraResult` gain `exScore`) and the C++ instance.
- DB bumped to v7: `scores` gains a nullable `exScore INT` column with an `ALTER TABLE` migration from v6; pre-v7 rows simply have no reading.
- Shown in the score card and score details page alongside the money score.
- EX readings are digit-only — commas stripped so the parse doesn't silently fail.

### 1P/2P by physical side (543f349, 8cfb513)
- Side selection now respects where the badge physically sits on screen rather than trusting detection order: the requested side's badge is promoted past the confidence gate, and frames where that badge isn't readable are skipped instead of falling back to the wrong player.

### Tap-to-correct Details ROI (8cfb513)
- In load-image, tapping a detected box overrides which box is treated as the Details ROI. The tap coordinates go through the FFI (`tapX`/`tapY`) so the native side re-runs selection with the user's pick.

### UI fix (e02aea9)
- Flare dropdown items no longer overflow: rank text ellipsizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)