### PR TITLE
fix: BPM graph desync and difficulty defaults on song open

### DIFF
--- a/lib/components/song/song_chart.dart
+++ b/lib/components/song/song_chart.dart
@@ -5,11 +5,9 @@ library;
 
 import 'package:ddr_md/components/song/song_details.dart';
 import 'package:ddr_md/components/song_json.dart';
-import 'package:ddr_md/models/song_model.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:provider/provider.dart';
 
 class SongChart extends StatefulWidget {
   const SongChart({
@@ -77,17 +75,18 @@ class SongChartState extends State<SongChart> {
     super.initState();
     hasStops = widget.chart.stops.isNotEmpty;
     isShowingStops = true;
+    genBpmPoints(widget.chart);
   }
 
-  // Ensure that we're watching the songInfo.chart for any changes
+  // Regenerate the graph whenever the parent hands us a different chart,
+  // e.g. when the user picks a different difficulty.
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    late SongState songState = Provider.of<SongState>(context);
-    final charts = songState.songInfo!.charts;
-    genBpmPoints(songState.songInfo!.perChart
-        ? charts[songState.chosenDifficulty.clamp(0, charts.length - 1)]
-        : charts.first);
+  void didUpdateWidget(SongChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.chart != widget.chart) {
+      hasStops = widget.chart.stops.isNotEmpty;
+      genBpmPoints(widget.chart);
+    }
   }
 
   @override

--- a/lib/components/song_json.dart
+++ b/lib/components/song_json.dart
@@ -51,11 +51,7 @@ class SongInfo {
   /// highlight when switching modes drops a difficulty.
   Radar? radarFor(Modes mode, int chosenDifficulty) {
     final radars = mode == Modes.singles ? radarSingles : radarDoubles;
-    final levels = (mode == Modes.singles ? singles : doubles).toJson();
-    final available = levels.entries
-        .where((e) => e.value != null)
-        .map((e) => e.key)
-        .toList();
+    final available = (mode == Modes.singles ? singles : doubles).availableTypes;
     if (available.isEmpty) return null;
     return radars[available[chosenDifficulty.clamp(0, available.length - 1)]];
   }
@@ -330,4 +326,24 @@ class Difficulty {
         "hard": hard,
         "challenge": challenge,
       };
+
+  /// Difficulty type keys (beginner..challenge) that have a level, in the
+  /// canonical order used by chosenDifficulty's index (SongDifficultyPicker,
+  /// radarFor).
+  List<String> get availableTypes => toJson()
+      .entries
+      .where((e) => e.value != null)
+      .map((e) => e.key)
+      .toList();
+
+  /// Index into [availableTypes] of the first difficulty type at [level],
+  /// or null if none match.
+  int? chosenDifficultyForLevel(int level) {
+    final types = availableTypes;
+    final levels = toJson();
+    for (int i = 0; i < types.length; i++) {
+      if (levels[types[i]] == level) return i;
+    }
+    return null;
+  }
 }

--- a/lib/components/songlist/difficultylist_page.dart
+++ b/lib/components/songlist/difficultylist_page.dart
@@ -70,15 +70,21 @@ class _DifficultyListPageState extends State<DifficultyListPage> {
     'v-z',
   ];
 
+  // Below this similarity a result is considered noise and dropped, same
+  // threshold spirit as the OCR title matcher.
+  static const double _kMinSearchSimilarity = 0.3;
+
   // Search result handler; widgets are built lazily in suggestionsBuilder.
+  // Ranks by normalized Levenshtein similarity (same as OCR title matching)
+  // so close-but-not-exact spellings still sort to the top.
   void getMatch(String value) {
-    value = value.toLowerCase().trim();
+    value = value.trim();
     setState(() {
       _searchResults.clear();
       if (value == "") return;
-      _searchResults.addAll(Songs.list.where((SongInfo song) =>
-          song.title.toLowerCase().contains(value) ||
-          song.titletranslit.toLowerCase().contains(value)));
+      _searchResults.addAll(Songs.matchTitles(value, limit: Songs.list.length)
+          .where((match) => match.similarity >= _kMinSearchSimilarity)
+          .map((match) => match.song));
     });
   }
 

--- a/lib/components/songlist/difficultylist_page.dart
+++ b/lib/components/songlist/difficultylist_page.dart
@@ -20,10 +20,14 @@ class SongItem {
   SongItem({
     required this.songInfo,
     required this.isFav,
+    this.defaultDifficultyIndex,
   });
 
   SongInfo songInfo;
   bool isFav;
+  // chosenDifficulty index to open the song at, when a single level filter
+  // is active and matches one of this song's difficulty types.
+  int? defaultDifficultyIndex;
 }
 
 enum _ActiveFilterPanel {
@@ -228,6 +232,11 @@ class _DifficultyListPageState extends State<DifficultyListPage> {
       favCount = favList.length;
     });
 
+    // Only a single selected level unambiguously implies a difficulty type
+    // to default to when opening a song.
+    final int? filteredLevel =
+        _selectedLevels.length == 1 ? _selectedLevels.first : null;
+
     List<SongItem> songItems = [];
     for (SongInfo song in Songs.list) {
       if (!songMatchesFilters(song, mode)) {
@@ -236,7 +245,16 @@ class _DifficultyListPageState extends State<DifficultyListPage> {
       bool isFav =
           favList.any((Favorite fav) => fav.songTitle == song.titletranslit);
 
-      songItems.add(SongItem(songInfo: song, isFav: isFav));
+      final songDifficulty = mode == Modes.singles ? song.singles : song.doubles;
+      final defaultDifficultyIndex = filteredLevel == null
+          ? null
+          : songDifficulty.chosenDifficultyForLevel(filteredLevel);
+
+      songItems.add(SongItem(
+        songInfo: song,
+        isFav: isFav,
+        defaultDifficultyIndex: defaultDifficultyIndex,
+      ));
     }
 
     switch (sortType) {
@@ -385,6 +403,8 @@ class _DifficultyListPageState extends State<DifficultyListPage> {
                               songInfo: songItem.songInfo,
                               isFav: songItem.isFav,
                               isSearch: false,
+                              defaultDifficultyIndex:
+                                  songItem.defaultDifficultyIndex,
                               regenFavsCallback: regenFavCount,
                             );
                           },

--- a/lib/components/songlist/songlist_item.dart
+++ b/lib/components/songlist/songlist_item.dart
@@ -16,10 +16,13 @@ class SongListItem extends StatefulWidget {
       required this.songInfo,
       required this.isFav,
       required this.isSearch,
+      this.defaultDifficultyIndex,
       this.regenFavsCallback});
   final SongInfo songInfo;
   final bool isFav;
   final bool isSearch;
+  // chosenDifficulty index to open this song at, from an active level filter.
+  final int? defaultDifficultyIndex;
   final void Function()? regenFavsCallback; // callback function for navigator
 
   @override
@@ -93,7 +96,7 @@ class _SongListItemState extends State<SongListItem> {
       ),
       onTap: () async {
         songState.setSongInfo(widget.songInfo);
-        songState.setChosenDifficulty(0);
+        songState.setChosenDifficulty(widget.defaultDifficultyIndex ?? 0);
         await Navigator.push(context,
                 MaterialPageRoute(builder: (context) => const SongPage()))
             .then((_) {

--- a/lib/models/song_model.dart
+++ b/lib/models/song_model.dart
@@ -122,16 +122,27 @@ class Songs {
   static String _normalize(String s) =>
       s.toLowerCase().replaceAll(RegExp(r'[^\p{L}\p{N}]+', unicode: true), '');
 
-  // Similarity of [query] (already normalized) to a song: the best normalized
-  // Levenshtein score across its title, translit title, and name.
+  // Similarity of [query] (already normalized) to a song: the best score
+  // across its title, translit title, and name. An exact substring hit (e.g.
+  // typing a prefix of a long title) always wins, so short partial queries
+  // aren't drowned out by whole-string edit distance; otherwise falls back to
+  // normalized Levenshtein so typos still rank sensibly.
   static double _similarity(String query, SongInfo song) {
     double best = 0;
     for (final candidate in [song.title, song.titletranslit, song.name]) {
       final normalized = _normalize(candidate);
       if (normalized.isEmpty) continue;
-      final maxLen =
-          query.length > normalized.length ? query.length : normalized.length;
-      final similarity = 1 - levenshtein(query, normalized) / maxLen;
+      double similarity;
+      if (normalized.contains(query)) {
+        // Floor of 0.5 so a short substring match (e.g. a prefix of a long
+        // title) still ranks as a strong hit, not a weak one.
+        similarity = 0.5 + 0.5 * (query.length / normalized.length);
+      } else {
+        final maxLen = query.length > normalized.length
+            ? query.length
+            : normalized.length;
+        similarity = 1 - levenshtein(query, normalized) / maxLen;
+      }
       if (similarity > best) best = similarity;
     }
     return best;


### PR DESCRIPTION
## Summary
- Fix BPM graph staying on the first chart's data instead of updating when a different difficulty is selected — it now regenerates via `didUpdateWidget` whenever the chart prop actually changes, instead of relying on `didChangeDependencies` + Provider watch, which wasn't firing per-chart-selection.
- When opening a song from a list filtered to a single difficulty level, default `chosenDifficulty` to the chart matching that level instead of always index 0, so the difficulty/BPM view reflects what the user filtered for.
- Rank song search results by normalized Levenshtein similarity (with an exact-substring bonus so short prefix queries still win) instead of unordered substring `contains` matching, so close-but-imperfect queries surface the right song instead of whatever happened to match first.